### PR TITLE
fix: doc check miss coverxygen

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -65,7 +65,7 @@ runs:
       shell: bash
       run: |
         sudo apt-get install -y --force-yes python3-pip python3-setuptools python3-wheel
-        sudo pip3 install coverxygen
+        pip3 install coverxygen
 
     - name: install build depends
       if: inputs.installDepends == 'true'


### PR DESCRIPTION
sudo permission install can't be used by normal user when python version is up to 3.10

log: