### PR TITLE
fix: doc check miss coverxygen

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -79,6 +79,7 @@ runs:
       shell: bash
       run: |
         export CHECK_RES=`[[ x$CHECK_RES != x ]] && echo $CHECK_RES || echo doxygen_check_file.json`
+        export PYTHONPATH=/usr/lib/python3.10/site-packages/:$PYTHONPATH
         ${{inputs.genDocCommand}}
       env:
         CHECK_KIND:  ${{ inputs.checkKind }}


### PR DESCRIPTION
use PYTHONPATH add python module path, python3.10 default module path need to be change when python3.9 removed

log: