### PR TITLE
pip3开启强制安装

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -65,7 +65,7 @@ runs:
       shell: bash
       run: |
         sudo apt-get install -y --force-yes python3-pip python3-setuptools python3-wheel
-        pip3 install coverxygen
+        pip3 install coverxygen --break-system-package
 
     - name: install build depends
       if: inputs.installDepends == 'true'


### PR DESCRIPTION
pip3目前在debian环境下默认不让sudo安装python包了，使用--break-system-package强制开启

log: